### PR TITLE
Fix muning_client with Patched version of Python2.7.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 0.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix muning_client with Patched version of Python2.7.
+  [pcdummy]
 
 
 0.7.1 (2015-08-11)

--- a/Products/ZNagios/munin_client.py
+++ b/Products/ZNagios/munin_client.py
@@ -41,7 +41,7 @@ class GraphBase(object):
         request = urllib2.Request(url)
         if AUTHORIZATION:
             request.add_header('Authorization', 'Basic %s' %
-                               base64.encodestring(AUTHORIZATION))
+                               base64.b64encode(AUTHORIZATION))
         result = urllib2.urlopen(request).readlines()
         self.data = {}
         for line in result:


### PR DESCRIPTION
`base64.encodestring()` appends a "\n" which newer versions of urllib don't like, so we have to use
`base64.b64encode()`.

Signed-off-by: Rene Jochum rene@jochums.at
