### PR TITLE
make munin_client python2.7 compatible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Python2.7 compatibility for munin_client.py [fRiSi]
 
 
 0.7.2 (2016-09-26)

--- a/Products/ZNagios/check_zope.py
+++ b/Products/ZNagios/check_zope.py
@@ -54,7 +54,7 @@ def printHelp():
 
 try:
     optlist, args = getopt.getopt(sys.argv[1:], 'iVhH:p:d:r:a:v?',
-            ['version', 'help', 'hostname=', 'port=', 'database=', 
+            ['version', 'help', 'hostname=', 'port=', 'database=',
             'references=', 'authentication=', 'ignore-errors'])
 except getopt.GetoptError, errorStr:
     print errorStr
@@ -108,14 +108,15 @@ try:
     else:
         url = 'http://%s:%s/Control_Panel/nagios' % (hostName, port)
     request = urllib2.Request(url)
-    base64string = base64.encodestring('%s' % (authentication))[:-1]
-    request.add_header("Authorization", "Basic %s" % base64string)
+    if authentication:
+        base64string = base64.b64encode(authentication)
+        request.add_header("Authorization", "Basic %s" % base64string)
     htmlFile = urllib2.urlopen(request)
     data = htmlFile.readlines()
 except Exception, e:
     print e
     sys.exit(nagiosStateCritical)
-    
+
 result = {}
 # Blindly convert this to our dict:
 for x in data:
@@ -169,6 +170,6 @@ if not ignoreErrors:
 # Provide uptime
 uptime = result.get('uptime', 'unknown')
 
-print 'Up: %s Refcount: %s ZODB: %s Mb Errors: None' % (uptime, references, database_size/(1024*1024))
+print 'Up: %s Refcount: %s ZODB: %s Mb Errors: None' % (uptime, references, database_size / (1024 * 1024))
 
 sys.exit(nagiosStateOk)

--- a/Products/ZNagios/munin_client.py
+++ b/Products/ZNagios/munin_client.py
@@ -41,7 +41,7 @@ class GraphBase(object):
         request = urllib2.Request(url)
         if AUTHORIZATION:
             request.add_header('Authorization', 'Basic %s' %
-                               base64.encodestring(AUTHORIZATION))
+                               base64.b64encode(AUTHORIZATION))
         result = urllib2.urlopen(request).readlines()
         self.data = {}
         for line in result:
@@ -58,8 +58,8 @@ class SimpleGraph(GraphBase):
     title = ''
     name = ''
     key = ''
-    vlabel = ''  #label for y-axis, use name if vlabel is not specified
-    cdef = ''   #rpn-expression used to compute the value (eg `%s,86400,/') to devide the value by 86400
+    vlabel = ''  # label for y-axis, use name if vlabel is not specified
+    cdef = ''   # rpn-expression used to compute the value (eg `%s,86400,/') to devide the value by 86400
 
 
     def do_fetch(self):


### PR DESCRIPTION
in python2.7 urllib2.urlopen will fail if a header contains a newline-character
(see http://stackoverflow.com/a/23121331/810427)

so we replace `base64.encodestring` (which adds a '\n' at the end) with
`base64.b64encode`